### PR TITLE
Added support for docker API version prefixes

### DIFF
--- a/docker-proxy-acl.go
+++ b/docker-proxy-acl.go
@@ -45,7 +45,7 @@ func main() {
 
 	var routers [2]*mux.Router;
 	routers[0] = mux.NewRouter();
-	routers[1] = routers[0].PathPrefix("/{version:^[v][0-9]+[.][0-9]+$}").Subrouter();
+	routers[1] = routers[0].PathPrefix("/{version:[v][0-9]+[.][0-9]+}").Subrouter();
 
 	upstream := proxy.NewSocket("/var/run/docker.sock");
 
@@ -127,7 +127,6 @@ func main() {
 			m.HandleFunc("/_ping", upstream.Pass());
 		}
 	}
-
 
 	http.Handle("/", routers[0]);
 

--- a/docker-proxy-acl.go
+++ b/docker-proxy-acl.go
@@ -43,71 +43,93 @@ func main() {
 		allowedMap[s] = true;
 	}
 
-	m := mux.NewRouter();
+	var routers [2]*mux.Router;
+	routers[0] = mux.NewRouter();
+	routers[1] = routers[0].PathPrefix("/{version:^[v][0-9]+[.][0-9]+$}").Subrouter();
 
 	upstream := proxy.NewSocket("/var/run/docker.sock");
 
 	if allowedMap["containers"] {
 		fmt.Printf("Registering container handlers\n");
-		containers := m.PathPrefix("/containers").Subrouter();
-		containers.HandleFunc("/json", upstream.Pass());
-		containers.HandleFunc("/{name}/json", upstream.Pass());
+		for _, m := range routers {
+			containers := m.PathPrefix("/containers").Subrouter();
+			containers.HandleFunc("/json", upstream.Pass());
+			containers.HandleFunc("/{name}/json", upstream.Pass());
+		}
 	}
 
 	if allowedMap["images"] {
 		fmt.Printf("Registering images handlers\n");
-		containers := m.PathPrefix("/images").Subrouter();
-		containers.HandleFunc("/json", upstream.Pass());
-		containers.HandleFunc("/{name}/json", upstream.Pass());
-		containers.HandleFunc("/{name}/history", upstream.Pass());
+		for _, m := range routers {
+			containers := m.PathPrefix("/images").Subrouter();
+			containers.HandleFunc("/json", upstream.Pass());
+			containers.HandleFunc("/{name}/json", upstream.Pass());
+			containers.HandleFunc("/{name}/history", upstream.Pass());
+		}
 	}
 
 	if allowedMap["volumes"] {
 		fmt.Printf("Registering volumes handlers\n");
-		m.HandleFunc("/volumes", upstream.Pass());
-		m.HandleFunc("/volumes/{name}", upstream.Pass());
+		for _, m := range routers {
+			m.HandleFunc("/volumes", upstream.Pass());
+			m.HandleFunc("/volumes/{name}", upstream.Pass());
+		}
 	}
 
 	if allowedMap["networks"] {
 		fmt.Printf("Registering networks handlers\n");
-		m.HandleFunc("/networks", upstream.Pass());
-		m.HandleFunc("/networks/{name}", upstream.Pass());
+		for _, m := range routers {
+			m.HandleFunc("/networks", upstream.Pass());
+			m.HandleFunc("/networks/{name}", upstream.Pass());
+		}
 	}
 
 	if allowedMap["services"] {
 		fmt.Printf("Registering services handlers\n");
-		m.HandleFunc("/services", upstream.Pass());
-		m.HandleFunc("/services/{name}", upstream.Pass());
+		for _, m := range routers {
+			m.HandleFunc("/services", upstream.Pass());
+			m.HandleFunc("/services/{name}", upstream.Pass());
+		}
 	}
 
 	if allowedMap["tasks"] {
 		fmt.Printf("Registering tasks handlers\n");
-		m.HandleFunc("/tasks", upstream.Pass());
-		m.HandleFunc("/tasks/{name}", upstream.Pass());
+		for _, m := range routers {
+			m.HandleFunc("/tasks", upstream.Pass());
+			m.HandleFunc("/tasks/{name}", upstream.Pass());
+		}
 	}
 
 	if allowedMap["events"] {
 		fmt.Printf("Registering events handlers\n");
-		m.HandleFunc("/events", upstream.Pass());
+		for _, m := range routers {
+			m.HandleFunc("/events", upstream.Pass());
+		}
 	}
 
 	if allowedMap["version"] {
 		fmt.Printf("Registering version handlers\n");
-		m.HandleFunc("/version", upstream.Pass());
+		for _, m := range routers {
+			m.HandleFunc("/version", upstream.Pass());
+		}
 	}
 
 	if allowedMap["info"] {
 		fmt.Printf("Registering info handlers\n");
-		m.HandleFunc("/info", upstream.Pass());
+		for _, m := range routers {
+			m.HandleFunc("/info", upstream.Pass());
+		}
 	}
 
 	if allowedMap["ping"] {
 		fmt.Printf("Registering ping handlers\n");
-		m.HandleFunc("/_ping", upstream.Pass());
+		for _, m := range routers {
+			m.HandleFunc("/_ping", upstream.Pass());
+		}
 	}
 
 
-	http.Handle("/", m);
+	http.Handle("/", routers[0]);
 
 	l, err := net.Listen("unix", *filename)
 	os.Chmod(*filename, 0666);


### PR DESCRIPTION
Per the information available here [https://docs.docker.com/engine/api/v1.37/#section/Versioning](url) using the docker api without a version prefix is deprecated behavior. I therefor added a sub-route with a regex to support accessing endpoints prefixed with a version of the form /v1.30/.

Please take a close look at what i have done here as I am very new to go and its syntax.