### PR TITLE
Added new function PassStream for use by the events endpoint.

### DIFF
--- a/docker-proxy-acl.go
+++ b/docker-proxy-acl.go
@@ -103,7 +103,7 @@ func main() {
 	if allowedMap["events"] {
 		fmt.Printf("Registering events handlers\n");
 		for _, m := range routers {
-			m.HandleFunc("/events", upstream.Pass());
+			m.HandleFunc("/events", upstream.PassStream());
 		}
 	}
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -4,6 +4,7 @@ import "fmt"
 import "net"
 import "net/http"
 import "io/ioutil"
+import "bufio"
 
 type UpStream struct {
 	Name string;


### PR DESCRIPTION
I added a new function that handles the "events" endpoint. It is based on the solution found [here ](https://stackoverflow.com/questions/22108519/how-do-i-read-a-streaming-response-body-using-golangs-net-http-package). The code is rather primitive, hacked together from your existing PASS and GET functions, but it does seem to work. Please offer up any suggestions as to how it might be improved.